### PR TITLE
limit xmlsec version to < 1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 -e .
 
-xmlsec>=0.6.0
+xmlsec>=0.6.0,<1
 pyOpenSSL>=0.15.1
 
 lxml>=3.4.4

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     url='https://github.com/orcasgit/py-wsse/',
     packages=find_packages(),
     install_requires=[
-        'xmlsec>=0.6.0',
+        'xmlsec>=0.6.0,<1',
         'pyOpenSSL>=0.15.1',
         'lxml>=3.4.4',
     ],


### PR DESCRIPTION
@orcasgit/orcas-developers Please review. This works around the bug installing xmlsec==1.0.1 and gives us time to verify things work as expected with 1.0.1 before rolling it out to production servers.

https://github.com/mehcode/python-xmlsec/issues/39